### PR TITLE
coreboot: minor fix on memory ranges

### DIFF
--- a/payloads/libpayload/arch/x86/multiboot.c
+++ b/payloads/libpayload/arch/x86/multiboot.c
@@ -48,6 +48,8 @@ static int mb_add_memrange(struct sysinfo_t *info, unsigned long long base,
 
 	info->memrange[info->n_memranges].base = base;
 	info->memrange[info->n_memranges].size = size;
+	if (type > CB_MEM_VENDOR_RSVD)
+		type = CB_MEM_RESERVED;
 	info->memrange[info->n_memranges].type = type;
 	info->n_memranges++;
 

--- a/payloads/libpayload/include/sysinfo.h
+++ b/payloads/libpayload/include/sysinfo.h
@@ -31,7 +31,7 @@
 #define _SYSINFO_H
 
 /* Maximum number of memory range definitions. */
-#define SYSINFO_MAX_MEM_RANGES 32
+#define SYSINFO_MAX_MEM_RANGES 64
 /* Allow a maximum of 8 GPIOs */
 #define SYSINFO_MAX_GPIOS 8
 


### PR DESCRIPTION
1. enlarge max memory range entries to 64
2. For the unknown memory type which bootloader provides, set it to CB_MEM_RESERVED

Tracked-On: OAM-111353