### PR TITLE
Fix an issue for realloc

### DIFF
--- a/payloads/libpayload/libc/malloc.c
+++ b/payloads/libpayload/libc/malloc.c
@@ -295,12 +295,6 @@ void *realloc(void *ptr, size_t size)
 	/* Get the original size of the block. */
 	osize = SIZE(*((hdrtype_t *) pptr));
 
-	/*
-	 * Free the memory to update the tables - this won't touch the actual
-	 * memory, so we can still use it for the copy after we have
-	 * reallocated the new space.
-	 */
-	free(ptr);
 	ret = alloc(size, type);
 
 	/*
@@ -312,6 +306,8 @@ void *realloc(void *ptr, size_t size)
 
 	/* Copy the memory to the new location. */
 	memcpy(ret, ptr, osize > size ? size : osize);
+
+	free(ptr);
 
 	return ret;
 }


### PR DESCRIPTION
For realloc function, previously it will free the original buffer firstly and then alloc a new buffer from heap, then it will copy the content from the original buffer to the new buffer. This has no problem if the new buffer region has no overlap with the original buffer region. Once there is overlap between the original buffer region and the new buffer region, the original buffer's content may be modified by the alloc to store the buffer management metadata before we copy the content to the new buffer. Then we will get a new buffer with invalid data after realloc. Once this situation occurs, we may meet a random boot failure such as a kernel panic etc.

Tracked-On: OAM-115356